### PR TITLE
Update accent color and improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,21 @@ This Agent Skill packages UX writing expertise into a system that Claude can app
 
 ### What You Need
 
-This skill works with **Claude Code** (the AI coding assistant). If you don't have Claude Code yet, visit [claude.ai/code](https://claude.ai/code) to get started.
+This skill works with **Claude Desktop** and **Claude Code**. Choose the installation method that matches your setup.
 
-### Step-by-Step Installation
+### Quick Install (Claude Desktop)
+
+If you're using Claude Desktop, installation is simple:
+
+1. Download this skill (click the green **"Code"** button → **"Download ZIP"**)
+2. Open Claude Desktop
+3. Go to **Settings** → **Capabilities** → **Upload skill**
+4. Select the downloaded skill file
+5. Start using the skill immediately!
+
+### Manual Install (Claude Code)
+
+If you're using Claude Code, follow these steps:
 
 **Step 1: Download This Skill**
 

--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@
             --ink: #1a1614;
             --ink-light: #4a4540;
             --ink-muted: #8a857f;
-            --accent: #E8A87C;
-            --accent-dark: #b88a5f;
+            --accent: #BACDD9;
+            --accent-dark: #9ab5c4;
             --border: rgba(26, 22, 20, 0.08);
             --border-dark: rgba(26, 22, 20, 0.15);
         }
@@ -601,6 +601,7 @@
 
         a {
             position: relative;
+            cursor: pointer;
         }
 
         .feature-card li:hover {
@@ -894,14 +895,14 @@
                 <h3 class="section-title">Get started</h3>
                 <div class="steps">
                     <div class="step">
-                        <div class="step-number">Step one</div>
-                        <h4>Download</h4>
-                        <p>Download the skill and extract the ZIP file to find the ux-writing folder.</p>
+                        <div class="step-number">Claude Desktop</div>
+                        <h4>Upload directly</h4>
+                        <p>In Claude Desktop, go to Settings → Capabilities → Upload skill, then select the downloaded skill file.</p>
                     </div>
                     <div class="step">
-                        <div class="step-number">Step two</div>
-                        <h4>Install</h4>
-                        <p>Copy the ux-writing folder to ~/.claude/skills/ and restart Claude Code.</p>
+                        <div class="step-number">Claude Code</div>
+                        <h4>Manual install</h4>
+                        <p>Copy the ux-writing folder to ~/.claude/skills/ and restart Claude Code to activate.</p>
                     </div>
                     <div class="step">
                         <div class="step-number">Step three</div>


### PR DESCRIPTION
- Change accent color from orange (#E8A87C) to blue-gray (#BACDD9)
- Add Claude Desktop installation instructions (Settings → Capabilities → Upload skill)
- Update README with quick install section for Claude Desktop
- Add cursor: pointer to all links for better UX
- Restructure Get started section to show both installation methods