### PR TITLE
Switch to self-hosted video and use outline play icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -803,7 +803,7 @@
             background: #1a1614;
         }
 
-        .video-content iframe {
+        .video-content video {
             position: absolute;
             top: 0;
             left: 0;
@@ -845,7 +845,7 @@
                 <a href="https://github.com/content-designer/ux-writing-skill">Repository</a>
                 <a href="https://github.com/content-designer/ux-writing-skill/blob/main/docs/figma-integration.md">Figma</a>
                 <a href="https://github.com/content-designer/ux-writing-skill#usage-examples">Documentation</a>
-                <button class="video-trigger" onclick="toggleVideo()">▶</button>
+                <button class="video-trigger" onclick="toggleVideo()">▷</button>
                 <button class="terminal-trigger" onclick="toggleTerminal()">></button>
             </nav>
         </div>
@@ -1056,7 +1056,10 @@
             </div>
         </div>
         <div class="video-content">
-            <iframe src="https://screen.studio/share/5WeHlEbQ" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+            <video controls style="width: 100%; height: 100%;">
+                <source src="https://raw.githubusercontent.com/content-designer/ux-writing-skill/main/ux-writing-skill-vid.mp4" type="video/mp4">
+                Your browser does not support the video tag.
+            </video>
         </div>
     </div>
 


### PR DESCRIPTION
- Replace Screen Studio iframe with GitHub-hosted MP4 video
- Use native HTML5 video element with controls
- Change play icon from filled (▶) to outline (▷) for consistency
- Update CSS to target video element instead of iframe