### PR TITLE
Reorganize skill packaging and clarify installation

### DIFF
--- a/.github/workflows/build-skill.yml
+++ b/.github/workflows/build-skill.yml
@@ -1,0 +1,30 @@
+name: Build Skill Package
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build skill package
+      run: ./build-skill.sh
+
+    - name: Upload skill package as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ux-writing-skill
+        path: dist/ux-writing-skill.zip
+
+    - name: Upload to release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: dist/ux-writing-skill.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Build output
+dist/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/README.md
+++ b/README.md
@@ -65,84 +65,45 @@ This skill works with **Claude Desktop** and **Claude Code**. Choose the install
 
 If you're using Claude Desktop, installation is simple:
 
-1. Download this skill (click the green **"Code"** button → **"Download ZIP"**)
-2. Open Claude Desktop
-3. Go to **Settings** → **Capabilities** → **Upload skill**
-4. Select the downloaded skill file
-5. Start using the skill immediately!
+1. **Download** [ux-writing-skill.zip](https://github.com/content-designer/ux-writing-skill/releases/latest/download/ux-writing-skill.zip) — this contains just the skill files and documentation
+2. Open **Claude Desktop**
+3. Go to **Settings → Capabilities → Skills**
+4. Click **Upload skill** and select **ux-writing-skill.zip**
+5. **Upload the ZIP file directly** — do not extract it first
+6. Start using the skill immediately!
+
+The ZIP contains only skill-relevant files: `SKILL.md` plus supporting documentation in `docs/`, `examples/`, `references/`, and `templates/`.
 
 ### Manual Install (Claude Code)
 
 If you're using Claude Code, follow these steps:
 
-**Step 1: Download This Skill**
+**Step 1: Download the Skill**
 
-1. On this GitHub page, look for the green **"Code"** button near the top
-2. Click it and select **"Download ZIP"**
-3. Find the downloaded file (usually in your Downloads folder)
-4. Double-click the ZIP file to extract it
+1. Download [ux-writing-skill.zip](https://github.com/content-designer/ux-writing-skill/releases/latest/download/ux-writing-skill.zip)
+2. Extract the ZIP file (double-click on Mac, right-click → Extract on Windows)
 
-**Step 2: Find Your Skills Folder**
+**Step 2: Copy to Skills Folder**
 
-The skills folder is where Claude Code looks for custom skills. Here's how to find or create it:
+Copy the extracted folder to your Claude skills directory:
 
-**On Mac:**
-1. Open Finder
-2. Press `Command + Shift + G` (this opens "Go to Folder")
-3. Type: `~/.claude/skills`
-4. Press Enter
-5. If you see "folder doesn't exist", create it:
-   - Type `~/.claude` instead and press Enter
-   - Right-click in the window and select "New Folder"
-   - Name it `skills`
+- **Mac/Linux**: `~/.claude/skills/`
+- **Windows**: `%USERPROFILE%\.claude\skills\`
 
-**On Windows:**
-1. Open File Explorer
-2. In the address bar, type: `%USERPROFILE%\.claude\skills`
-3. Press Enter
-4. If you see "folder doesn't exist", create it:
-   - Type `%USERPROFILE%\.claude` instead and press Enter
-   - Right-click and select "New" → "Folder"
-   - Name it `skills`
+Create the directory if it doesn't exist.
 
-**Step 3: Install the Skill**
+**Step 3: Restart Claude Code**
 
-1. Open the extracted folder from Step 1
-2. Inside, you'll see a folder called `ux-writing`
-3. **Copy the entire `ux-writing` folder** (not just the files inside it)
-4. Paste it into your skills folder from Step 2
+Quit and reopen Claude Code to activate the skill.
 
-Your skills folder should now look like this:
-```
-.claude/
-  skills/
-    ux-writing/
-      SKILL.md
-      references/
-      examples/
-      templates/
-      (and other files)
-```
+**Verify It's Working**
 
-**Step 4: Restart Claude Code**
-
-1. Completely quit Claude Code (don't just close the window)
-2. Reopen Claude Code
-3. The skill is now installed!
-
-**Step 5: Verify It's Working**
-
-Try asking Claude Code:
+Try asking Claude:
 ```
 Write an error message for when a payment fails
 ```
 
-If the skill is working, Claude will apply UX writing best practices and create a clear, empathetic error message. You can also ask:
-```
-What UX writing skills do you have?
-```
-
-Claude should mention the UX Writing Skill in its response.
+Claude will apply UX writing best practices and create a clear, empathetic error message.
 
 ### For Teams: Project Installation
 
@@ -266,11 +227,23 @@ Built by [Christopher Greer](https://www.linkedin.com/in/christopher-greer/), St
 Contributions welcome! If you have:
 
 - Additional reference patterns
-- More real-world examples  
+- More real-world examples
 - Template improvements
 - Translations to other languages
 
 Please open an issue or submit a pull request.
+
+### Building the Skill Package
+
+If you're contributing or want to build the skill ZIP locally:
+
+```bash
+./build-skill.sh
+```
+
+This creates `dist/ux-writing-skill.zip` containing only the skill files (`SKILL.md`, `docs/`, `examples/`, `references/`, `templates/`).
+
+The build script excludes repository files like `README.md`, `CONTRIBUTING.md`, `index.html`, and the demo video — these live on GitHub but aren't needed in the skill package.
 
 ## License
 

--- a/build-skill.sh
+++ b/build-skill.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Build script to package UX Writing Skill for distribution
+# This creates a ZIP file containing only the skill files needed by Claude
+
+set -e
+
+OUTPUT_DIR="dist"
+ZIP_NAME="ux-writing-skill.zip"
+
+echo "Building UX Writing Skill package..."
+
+# Create dist directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+# Remove old ZIP if it exists
+rm -f "$OUTPUT_DIR/$ZIP_NAME"
+
+# Create ZIP with only skill-relevant files
+zip -r "$OUTPUT_DIR/$ZIP_NAME" \
+  SKILL.md \
+  docs/ \
+  examples/ \
+  references/ \
+  templates/ \
+  -x "*.DS_Store" "*.git*"
+
+echo "✓ Skill package created: $OUTPUT_DIR/$ZIP_NAME"
+echo ""
+echo "Contents:"
+unzip -l "$OUTPUT_DIR/$ZIP_NAME"

--- a/index.html
+++ b/index.html
@@ -856,7 +856,7 @@
                 <h2>Write better<br>interface copy</h2>
                 <p class="subtitle">A comprehensive skill for Claude Code that helps content designers and product teams create accessible, user-centered text following research-backed best practices.</p>
                 <div class="cta-buttons">
-                    <a href="https://github.com/content-designer/ux-writing-skill/archive/refs/heads/main.zip" class="btn btn-primary">Download skill</a>
+                    <a href="https://github.com/content-designer/ux-writing-skill/releases/latest/download/ux-writing-skill.zip" class="btn btn-primary">Download skill</a>
                     <a href="https://github.com/content-designer/ux-writing-skill" class="btn btn-secondary">View on GitHub</a>
                 </div>
             </div>
@@ -978,17 +978,16 @@
                 <div class="steps">
                     <div class="step">
                         <div class="step-number">Step 1</div>
-                        <h4>Download file</h4>
-                        <p>Download the ZIP file here or from GitHub.</p>
+                        <h4>Download</h4>
+                        <p>Download <strong>ux-writing-skill.zip</strong> — contains the skill file and all supporting documentation.</p>
                 </div>
-                
+
                 <div class="step">
                     <div class="step-number">Step 2</div>
-                    <h4>Upload file</h4>
-                    <p>In Claude Desktop, open <strong>Settings → Capabilities → Skills</strong>, then click
-                        <strong>Upload skill</strong> and select the ZIP file you downloaded. You can also copy the ZIP file into <code>~/.claude/skills/</code> and restart Claude to activate it.</p>
+                    <h4>Upload</h4>
+                    <p>In Claude Desktop, open <strong>Settings → Capabilities → Skills</strong>, click <strong>Upload skill</strong>, and select <strong>ux-writing-skill.zip</strong>. Upload the ZIP file directly without extracting it.</p>
                     </div>
-                
+
                 <div class="step">
                         <div class="step-number">Step 3</div>
                         <h4>Use</h4>


### PR DESCRIPTION
Build System:
- Add build-skill.sh script to create distribution ZIP
- ZIP contains only skill files: SKILL.md, docs/, examples/, references/, templates/
- Excludes repo files: README, CONTRIBUTING, index.html, video
- Add GitHub Actions workflow to auto-build on releases
- Add .gitignore for dist/ and common OS/editor files

Installation Updates:
- Update index.html download link to releases/latest/download/ux-writing-skill.zip
- Clarify instructions: upload ZIP directly without extracting
- Rename ZIP to 'ux-writing-skill.zip' for clarity
- Simplify installation steps in README
- Add build instructions for contributors

The skill package now contains only what Claude needs, while documentation and demos remain on GitHub for discovery.