### PR TITLE
Update download links to main and add auto-rebuild workflow

### DIFF
--- a/.github/workflows/auto-rebuild-skill.yml
+++ b/.github/workflows/auto-rebuild-skill.yml
@@ -1,0 +1,45 @@
+name: Auto-rebuild Skill Package
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'SKILL.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'references/**'
+      - 'templates/**'
+      - 'build-skill.sh'
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+
+    # Skip if commit was made by the bot to prevent infinite loops
+    if: "!contains(github.event.head_commit.message, '[auto-rebuild]')"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build skill package
+      run: ./build-skill.sh
+
+    - name: Check for changes
+      id: check_changes
+      run: |
+        if git diff --quiet dist/ux-writing-skill.zip; then
+          echo "changed=false" >> $GITHUB_OUTPUT
+        else
+          echo "changed=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Commit updated ZIP
+      if: steps.check_changes.outputs.changed == 'true'
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add dist/ux-writing-skill.zip
+        git commit -m "Auto-rebuild skill package [auto-rebuild]"
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-# Build output (commit the skill ZIP for direct downloads until first release)
+# Build output
+# Note: dist/ is committed to enable direct downloads from GitHub
+# The auto-rebuild workflow keeps it in sync when skill files change
 # dist/
 
 # OS files

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This skill works with **Claude Desktop** and **Claude Code**. Choose the install
 
 If you're using Claude Desktop, installation is simple:
 
-1. **Download** [ux-writing-skill.zip](https://github.com/content-designer/ux-writing-skill/raw/claude/fix-video-modal-behavior-011CV2BozzuQbWSS3jRrn6kU/dist/ux-writing-skill.zip) — this contains just the skill files and documentation
+1. **Download** [ux-writing-skill.zip](https://github.com/content-designer/ux-writing-skill/raw/main/dist/ux-writing-skill.zip) — this contains just the skill files and documentation
 2. Open **Claude Desktop**
 3. Go to **Settings → Capabilities → Skills**
 4. Click **Upload skill** and select **ux-writing-skill.zip**
@@ -80,7 +80,7 @@ If you're using Claude Code, follow these steps:
 
 **Step 1: Download the Skill**
 
-1. Download [ux-writing-skill.zip](https://github.com/content-designer/ux-writing-skill/raw/claude/fix-video-modal-behavior-011CV2BozzuQbWSS3jRrn6kU/dist/ux-writing-skill.zip)
+1. Download [ux-writing-skill.zip](https://github.com/content-designer/ux-writing-skill/raw/main/dist/ux-writing-skill.zip)
 2. Extract the ZIP file (double-click on Mac, right-click → Extract on Windows)
 
 **Step 2: Copy to Skills Folder**

--- a/index.html
+++ b/index.html
@@ -856,7 +856,7 @@
                 <h2>Write better<br>interface copy</h2>
                 <p class="subtitle">A comprehensive skill for Claude Code that helps content designers and product teams create accessible, user-centered text following research-backed best practices.</p>
                 <div class="cta-buttons">
-                    <a href="https://github.com/content-designer/ux-writing-skill/raw/claude/fix-video-modal-behavior-011CV2BozzuQbWSS3jRrn6kU/dist/ux-writing-skill.zip" class="btn btn-primary">Download skill</a>
+                    <a href="https://github.com/content-designer/ux-writing-skill/raw/main/dist/ux-writing-skill.zip" class="btn btn-primary">Download skill</a>
                     <a href="https://github.com/content-designer/ux-writing-skill" class="btn btn-secondary">View on GitHub</a>
                 </div>
             </div>


### PR DESCRIPTION
Download Links:
- Updated all download URLs from branch name to 'main'
- Links now point to stable main branch location

Auto-Rebuild Workflow:
- Created .github/workflows/auto-rebuild-skill.yml
- Triggers when skill files change (SKILL.md, docs/, examples/, references/, templates/)
- Automatically rebuilds and commits updated ZIP to main
- Prevents infinite loops with [auto-rebuild] commit message check
- Ensures download always contains latest skill content

This means:
- Contributors don't need to manually rebuild the ZIP
- Downloads stay fresh automatically
- No release required for updates to work