### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # UX Writing Skill for Claude
 
+[![Run in Smithery](https://smithery.ai/badge/skills/content-designer)](https://smithery.ai/skills?ns=content-designer&utm_source=github&utm_medium=badge)
+
+
 > Scale content quality through AI-powered design system enforcement
 
 **🌐 [View Website](https://content-designer.github.io/ux-writing-skill/)**


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/content-designer)](https://smithery.ai/skills?ns=content-designer&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.