### PR TITLE
Add OpenAI Codex and ChatGPT Figma app support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# UX Writing Skill for Claude
+# UX Writing Skill for Claude & Codex
 
 [![Run in Smithery](https://smithery.ai/badge/skills/content-designer)](https://smithery.ai/skills?ns=content-designer&utm_source=github&utm_medium=badge)
 
@@ -7,7 +7,7 @@
 
 **🌐 [View Website](https://content-designer.github.io/ux-writing-skill/)**
 
-An Agent Skill that enables Claude to write and edit user-centered interface copy (UX text/microcopy) for digital products. This skill transforms Claude into a specialized UX writing assistant that applies consistent standards, patterns, and voice across your product.
+An Agent Skill that enables Claude and OpenAI Codex to write and edit user-centered interface copy (UX text/microcopy) for digital products. This skill transforms AI assistants into specialized UX writing tools that apply consistent standards, patterns, and voice across your product.
 
 ## The Problem
 
@@ -64,7 +64,7 @@ This Agent Skill packages UX writing expertise into a system that Claude can app
 
 ### What You Need
 
-This skill works with **Claude Desktop** and **Claude Code**. Choose the installation method that matches your setup.
+This skill works with **Claude Desktop**, **Claude Code**, and **OpenAI Codex**. Choose the installation method that matches your setup.
 
 ### Quick Install (Claude Desktop)
 
@@ -110,27 +110,70 @@ Write an error message for when a payment fails
 
 Claude will apply UX writing best practices and create a clear, empathetic error message.
 
+### Install in Codex (OpenAI)
+
+If you're using OpenAI Codex, installation is straightforward:
+
+**Step 1: Download the Skill**
+
+1. Download [ux-writing-skill.zip](https://github.com/content-designer/ux-writing-skill/raw/main/dist/ux-writing-skill.zip)
+2. Extract the ZIP file
+
+**Step 2: Copy to Codex Skills Folder**
+
+Copy the extracted folder to your Codex skills directory:
+
+- **Mac/Linux**: `~/.codex/skills/`
+- **Windows**: `%USERPROFILE%\.codex\skills\`
+
+Create the directory if it doesn't exist.
+
+**Step 3: Restart Codex**
+
+Quit and reopen Codex (or your IDE with Codex extension) to activate the skill.
+
+**Verify It's Working**
+
+Try asking in Codex:
+```
+Write an error message for when a payment fails
+```
+
+Codex will apply UX writing best practices and create a clear, empathetic error message.
+
+**Alternative: Use the Built-in Skill Creator**
+
+You can also use Codex's built-in skill creator:
+1. In Codex CLI or IDE, type `$skill-creator`
+2. Provide the path to the extracted skill folder
+3. Follow the prompts to install
+
 ### For Teams: Project Installation
 
 Want your whole team to use this skill automatically?
 
+**For Claude Code:**
 1. Copy the `ux-writing` folder to `.claude/skills/` in your project's root directory
-2. Commit it to your repository (Git, etc.)
+2. Commit it to your repository
 3. When teammates pull the code, they'll automatically get the skill
+4. **Note**: Project skills only work when Claude Code is opened in that project folder
 
-**Note**: Project skills only work when Claude Code is opened in that project folder.
+**For Codex:**
+1. Copy the `ux-writing` folder to `.codex/skills/` in your project's root directory
+2. Commit it to your repository
+3. When teammates pull the code, they'll automatically get the skill
 
 ## Figma Integration
 
 **Review and improve UX copy directly from your Figma designs!**
 
-Connect this skill to Figma so Claude can analyze mockups, audit copy, and suggest improvements based on UX writing best practices. Perfect for:
+Connect this skill to Figma through Claude Code or ChatGPT to analyze mockups, audit copy, and suggest improvements based on UX writing best practices. Perfect for:
 - Content designers reviewing flows before launch
 - Product teams iterating on copy in designs
 - Design QA and accessibility audits
 - Cross-platform consistency checks
 
-### Quick Start
+### Quick Start with Claude Code
 
 1. **Connect Figma to Claude Code** (one-time setup):
    ```bash
@@ -148,7 +191,30 @@ Connect this skill to Figma so Claude can analyze mockups, audit copy, and sugge
 
 3. **Get instant feedback** with specific improvements based on the four quality standards.
 
-**📖 Full setup guide and workflows:** [docs/figma-integration.md](docs/figma-integration.md)
+**📖 Full Claude Code setup guide:** [docs/figma-integration.md](docs/figma-integration.md)
+
+### Quick Start with ChatGPT Figma App
+
+1. **Connect Figma to ChatGPT** (one-time setup):
+   - Open ChatGPT
+   - Click your profile → **Apps & connectors**
+   - Find **Figma** and click **Connect**
+   - Follow prompts to authenticate
+
+2. **Ask ChatGPT to review your designs**:
+   ```
+   Review the UX copy in this design:
+   https://www.figma.com/file/abc123/Design?node-id=123-456
+
+   Using UX writing best practices, check for:
+   - Button labels and clarity
+   - Error message quality
+   - Tone consistency
+   ```
+
+3. **Get instant feedback** based on the UX Writing Skill's quality standards.
+
+**📖 Full ChatGPT/Codex setup guide:** [docs/codex-figma-integration.md](docs/codex-figma-integration.md)
 
 ## Usage Examples
 
@@ -189,7 +255,7 @@ Claude uses the content usability checklist to provide detailed scoring and impr
 
 ## How It Works
 
-This skill uses **model-invoked activation** — Claude automatically decides when to use it based on your request. You don't need to explicitly call the skill; it activates when you:
+This skill uses **model-invoked activation** — Claude and Codex automatically decide when to use it based on your request. You don't need to explicitly call the skill; it activates when you:
 
 - Write or edit interface copy
 - Create error messages, notifications, or empty states
@@ -197,7 +263,9 @@ This skill uses **model-invoked activation** — Claude automatically decides wh
 - Review product content for consistency
 - Establish voice and tone guidelines
 
-Claude loads reference materials progressively, using only what's needed for your specific task to maintain efficient context usage.
+The AI loads reference materials progressively, using only what's needed for your specific task to maintain efficient context usage.
+
+**In Codex**, you can also explicitly invoke the skill using `$ux-writing` or through the `/skills` command.
 
 ## What You'll Learn
 
@@ -258,9 +326,15 @@ MIT License — use this skill freely in your projects and teams.
 
 Looking for more Agent Skills?
 
+**For Claude:**
 - Browse the [Claude Code Skills collection](https://github.com/anthropics/claude-code-skills)
 - Learn about [Agent Skills architecture](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)
 - Read [best practices for authoring skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices)
+
+**For OpenAI Codex:**
+- Explore [Codex Skills documentation](https://developers.openai.com/codex/skills/)
+- Learn how to [create custom skills](https://developers.openai.com/codex/skills/create-skill)
+- Join the [OpenAI Developer Community](https://community.openai.com/) to discuss skills
 
 ## Why This Matters
 

--- a/docs/codex-figma-integration.md
+++ b/docs/codex-figma-integration.md
@@ -1,0 +1,624 @@
+# Using UX Writing Skill with OpenAI Codex & ChatGPT Figma App
+
+Connect this skill to Figma through ChatGPT so you can review and improve copy directly from your designs. Perfect for content designers, product designers, and anyone who needs to audit or enhance UX text in Figma mockups.
+
+## What You Can Do
+
+Once connected, you can:
+- **Share Figma design links** with ChatGPT and get instant UX writing feedback
+- **Generate Figma designs** with improved copy using the ChatGPT Figma app
+- **Audit existing designs** for accessibility, clarity, and tone
+- **Review entire flows** for consistency and voice
+- **Get specific suggestions** based on the four quality standards (purposeful, concise, conversational, clear)
+
+## Quick Example
+
+```
+Here's my login screen: https://www.figma.com/file/abc123/Login
+
+Using UX writing best practices, review all the copy. Check for:
+- Accessibility (screen reader compatibility, plain language)
+- Error message clarity
+- Button labels
+- Tone consistency
+```
+
+ChatGPT will analyze the design, identify all text elements, and provide detailed feedback with specific improvements based on the UX Writing Skill.
+
+---
+
+## Setup: Connect Figma to ChatGPT
+
+### Requirements
+
+- ChatGPT account (Plus, Team, or Enterprise recommended for full access)
+- Figma account
+- Internet connection
+
+**Note**: The Figma app is available in English in markets where Figma services are offered. Currently not available in the EU.
+
+### Step-by-Step Setup
+
+**Step 1: Open ChatGPT**
+
+1. Go to [chatgpt.com](https://chatgpt.com) or open the ChatGPT app
+2. Make sure you're logged in
+
+**Step 2: Access Apps & Connectors**
+
+1. Click on your **profile** or **username** in the bottom left corner
+2. Select **"Apps & connectors"** from the menu
+3. Scroll through the available apps until you find **Figma**
+
+**Step 3: Connect Figma**
+
+1. Click on the **Figma** app
+2. Click **"Connect"**
+3. A new window will open asking you to authenticate with Figma
+4. Log in to your Figma account if prompted
+5. Click **"Allow access"** to give ChatGPT permission to access your Figma files
+
+**Step 4: Verify Connection**
+
+Ask ChatGPT:
+```
+Do you have access to Figma?
+```
+
+ChatGPT should confirm it can access Figma and explain what it can do.
+
+---
+
+## Alternative: Mention the App in Your Prompt
+
+You can also connect the Figma app by simply mentioning it in your prompt:
+
+```
+Figma, create a login screen with clear error messages
+```
+
+ChatGPT will prompt you to connect the Figma app if you haven't already, and guide you through the authentication process.
+
+---
+
+## How to Use with UX Writing Skill
+
+### Method 1: Review Existing Figma Designs
+
+**Step 1: Get Your Figma Link**
+
+1. Open your design in Figma (web or desktop app)
+2. Select the frame you want to review
+3. Right-click and select **"Copy link"**
+   - Or use the share button in the top right
+   - Or copy the URL from your browser
+
+**Step 2: Share with ChatGPT**
+
+Paste the link in ChatGPT along with your request:
+
+```
+Review the UX copy in this checkout flow:
+https://www.figma.com/file/abc123/Checkout?node-id=456-789
+
+Using the UX Writing Skill, check for:
+- Error messages (should be empathetic and actionable)
+- Button labels (should be specific verbs)
+- Form field labels (should be clear and accessible)
+- Overall tone (should be helpful and professional)
+```
+
+**Step 3: Get Detailed Feedback**
+
+ChatGPT will:
+1. Access the Figma design
+2. Extract all text elements
+3. Apply the UX Writing Skill automatically
+4. Provide specific, actionable feedback based on the four quality standards
+
+---
+
+### Method 2: Generate New Designs with Better Copy
+
+The ChatGPT Figma app can create designs from scratch with UX-optimized copy:
+
+```
+Figma, create an error state for a payment failure with:
+- Clear explanation of what went wrong
+- Specific next steps for the user
+- Empathetic tone
+- Follow UX writing best practices
+```
+
+ChatGPT will generate a Figma design with properly written UX copy following the skill's guidelines.
+
+**What You Can Create:**
+- Error states and messages
+- Onboarding flows
+- Empty states
+- Form designs with labels and helper text
+- Notification designs
+- Success confirmations
+- FigJam flowcharts and diagrams
+
+---
+
+### Method 3: Get Rewritten Copy for Existing Designs
+
+Ask ChatGPT to improve the copy in your designs:
+
+```
+Here's my error screen: [Figma link]
+
+Rewrite all the copy following UX writing best practices:
+- Make it more concise (target under 20 words per sentence)
+- Add specific recovery steps
+- Ensure screen reader accessibility
+- Use empathetic tone for frustrated users
+```
+
+ChatGPT will analyze the current copy, score it against the four quality standards, and provide improved versions.
+
+---
+
+## Example Workflows for Content Designers
+
+### 1. Quick UX Audit Before Launch
+
+```
+I need to review this feature before launch:
+https://www.figma.com/file/abc123/New-Feature
+
+Using the UX Writing Skill, audit all copy for:
+- Accessibility issues (screen reader compatibility, reading level)
+- Sentence length (should be under 20 words)
+- Button specificity (no generic "Submit" or "OK" buttons)
+- Error message quality (explain problem + solution)
+- Voice consistency
+
+Give me a prioritized list of issues to fix.
+```
+
+### 2. Voice and Tone Validation
+
+```
+Review the tone in these onboarding screens:
+https://www.figma.com/file/abc123/Onboarding
+
+Our product voice is: helpful, friendly, professional
+
+Check if all the copy matches this voice and suggest improvements
+where it doesn't. Use the tone adaptation framework from the UX Writing Skill.
+```
+
+### 3. Comprehensive Accessibility Check
+
+```
+Audit this form for accessibility:
+https://www.figma.com/file/abc123/Contact-Form
+
+Using accessibility guidelines from the UX Writing Skill, check:
+- Screen reader compatibility
+- Form labels (visible, not placeholder-only)
+- Error messages (descriptive and actionable)
+- Plain language (7th-8th grade reading level)
+- Link text (descriptive, not "click here")
+```
+
+### 4. Before/After Analysis with Scoring
+
+```
+Here's my current empty state: [Figma link]
+
+Using the UX Writing Skill:
+1. Score the current copy against the 4 quality standards (purposeful, concise, conversational, clear)
+2. Identify specific problems
+3. Provide rewritten version with improvements
+4. Explain what changed and why
+```
+
+### 5. Multi-Platform Consistency Check
+
+```
+Compare copy across these platform designs:
+- Web: [Figma link 1]
+- iOS: [Figma link 2]
+- Android: [Figma link 3]
+
+Check for:
+- Terminology consistency
+- Tone consistency
+- Platform-specific conventions (e.g., "tap" vs "click")
+- Character count appropriateness for each platform
+```
+
+### 6. Create New Designs with Optimized Copy
+
+```
+Figma, create a 3-screen onboarding flow for a budgeting app with:
+- Welcome screen introducing the value proposition
+- Account setup with clear form labels
+- Preferences selection with helpful descriptions
+
+Follow UX writing best practices:
+- Concise (40-60 characters per line)
+- Clear value to user
+- Encouraging tone
+- 7th-8th grade reading level
+```
+
+---
+
+## Tips for Best Results
+
+### Be Explicit About Using the UX Writing Skill
+
+For best results, explicitly mention the UX Writing Skill in your prompts:
+
+❌ **Too vague:**
+> "Review this design: [link]"
+
+✅ **Better:**
+> "Using the UX Writing Skill, review error messages in this form: [link]. Check against the four quality standards."
+
+### Reference Specific Frameworks
+
+The UX Writing Skill includes several frameworks you can call out:
+
+```
+Use the tone adaptation framework to suggest appropriate tone for this error state: [link]
+```
+
+```
+Apply the content usability checklist to score this copy: [link]
+```
+
+```
+Check this against the accessibility guidelines in the UX Writing Skill
+```
+
+### Ask for Specific Patterns
+
+```
+Review all buttons in this flow: [link]
+
+Check that they follow the button pattern:
+- Active imperative verbs
+- [Verb] [object] format
+- Specific, not generic
+- Under 25 characters
+```
+
+### Combine Analysis with Creation
+
+```
+Review the error messages in this design: [link]
+
+Then, Figma, create improved versions using:
+- Clear explanation + specific next steps
+- Empathetic tone
+- Under 18 words total
+- Accessible language
+```
+
+### Request Comprehensive Documentation
+
+```
+Analyze all the copy in this product: [link 1] [link 2] [link 3]
+
+Create a content style guide showing:
+- Common patterns we use
+- Voice characteristics
+- Terminology conventions
+- Do/don't examples from our actual designs
+```
+
+---
+
+## What the ChatGPT Figma App Can Create
+
+### Design Assets
+- Social media posts
+- Digital ads and marketing materials
+- Presentation slides (Figma Slides)
+- UI mockups and wireframes
+
+### Diagrams (FigJam)
+- Flowcharts
+- Sequence diagrams
+- State diagrams
+- Gantt charts
+- User journey maps
+- Site maps
+
+### Starting Prompts
+```
+Figma, create a flowchart showing the user login process
+```
+
+```
+Figma, make a presentation about our Q4 product roadmap
+```
+
+```
+Figma, design a social media post announcing our new feature
+```
+
+---
+
+## Using with Codex CLI or IDE
+
+If you're using Codex in your terminal or IDE, you can invoke the UX Writing Skill explicitly:
+
+### Explicit Invocation
+
+```
+$ux-writing review this error message: "An error occurred"
+```
+
+### Skill Selection with /skills
+
+1. Type `/skills` in Codex
+2. Select the **ux-writing** skill from the list
+3. Describe your task
+
+### Auto-Invocation
+
+Codex can automatically activate the skill when it detects UX writing tasks:
+
+```
+I need to write better button labels for my checkout flow
+```
+
+Codex will recognize this as a UX writing task and automatically use the skill.
+
+---
+
+## Troubleshooting
+
+### "I don't have access to that Figma file"
+
+**Solutions:**
+1. Make sure the Figma file is set to "Anyone with the link can view"
+2. Check that you're signed into the same Figma account you connected to ChatGPT
+3. Try copying the link again (might have been truncated or expired)
+4. Share the file explicitly with the email associated with your connected Figma account
+
+### "The Figma app isn't showing up in my Apps list"
+
+**Solutions:**
+1. Check if Figma is available in your region (currently not available in EU)
+2. Make sure you're using an updated version of ChatGPT
+3. Try accessing from the web version: [chatgpt.com/apps](https://chatgpt.com/apps)
+4. Search for "Figma" in the apps list
+
+### "ChatGPT isn't using the UX Writing Skill"
+
+**Solution:**
+
+Be more explicit in your prompt:
+
+```
+Using the UX Writing Skill, review this design: [link]
+
+Apply the four quality standards:
+1. Purposeful
+2. Concise
+3. Conversational
+4. Clear
+```
+
+Or reference specific components:
+
+```
+Use UX writing best practices to check these error messages: [link]
+```
+
+### "The skill isn't installed in Codex"
+
+**Solution:**
+
+Verify the skill is in the correct location:
+- **Mac/Linux**: `~/.codex/skills/ux-writing/SKILL.md`
+- **Windows**: `%USERPROFILE%\.codex\skills\ux-writing\SKILL.md`
+
+Restart Codex after installation.
+
+Check installed skills:
+```
+/skills
+```
+
+### "Connection to Figma keeps disconnecting"
+
+**Solution:**
+1. Go to your ChatGPT profile → Apps & connectors
+2. Find Figma and click **Disconnect**
+3. Wait 30 seconds
+4. Click **Connect** again and re-authenticate
+5. Test with a simple request: "Can you access my Figma files?"
+
+---
+
+## Example: Complete UX Audit Workflow
+
+Here's a real-world example of conducting a comprehensive UX writing audit:
+
+```
+I'm reviewing our checkout flow before launch. Here are the 4 screens:
+
+1. Cart: https://www.figma.com/file/abc/cart?node-id=123
+2. Shipping: https://www.figma.com/file/abc/shipping?node-id=456
+3. Payment: https://www.figma.com/file/abc/payment?node-id=789
+4. Confirmation: https://www.figma.com/file/abc/confirm?node-id=012
+
+Using the UX Writing Skill, perform a complete audit:
+
+**Check for:**
+- All 4 quality standards (purposeful, concise, conversational, clear)
+- Accessibility (screen readers, reading level, plain language)
+- Error messages (empathetic, actionable, specific)
+- Form labels (visible, descriptive, not placeholder-only)
+- Button labels (specific verbs, not generic)
+- Voice consistency across all screens
+- Appropriate tone for context
+
+**Provide:**
+1. Overall score (1-10) with explanation
+2. Critical issues (must fix before launch)
+3. Recommended improvements (nice to have)
+4. Rewritten copy for any critical issues
+5. Summary of patterns used well
+
+Format as a design review report.
+```
+
+---
+
+## Rate Limits and Availability
+
+### ChatGPT Plan Limits
+
+The Figma app availability may vary by ChatGPT plan:
+- **Free users**: Limited app access
+- **Plus users**: Full app access recommended
+- **Team/Enterprise**: Full access with higher rate limits
+
+### Geographic Availability
+
+The Figma app in ChatGPT is currently:
+- ✅ Available in most markets where Figma operates
+- ❌ Not available in the EU
+
+### Best Practices for Rate Limits
+
+If you're doing extensive reviews:
+- Batch your requests (review multiple screens in one prompt)
+- Be specific about what you want checked
+- Save complex multi-file audits for when you need them most
+
+---
+
+## Advanced Usage
+
+### Create a Content Pattern Library
+
+```
+Review all designs in our product: [links to key flows]
+
+Extract and document our content patterns:
+- Button naming conventions we use
+- Error message structure
+- Empty state patterns
+- Success message patterns
+- Voice characteristics (with examples)
+
+Create a pattern library I can share with the team.
+```
+
+### Generate Localization-Ready Designs
+
+```
+Figma, create a settings screen with:
+- Text that can expand 30-40% (for German translation)
+- No idioms or cultural references
+- Flexible button widths
+- Universal icons with text labels
+
+Use UX writing best practices for international audiences.
+```
+
+### Build a Voice Chart from Existing Designs
+
+```
+Analyze the copy in these designs: [multiple links]
+
+Using the voice chart template from the UX Writing Skill, create a voice chart showing:
+- 3-5 key brand concepts
+- Voice characteristics for each
+- Do/Don't examples from our actual product
+- Tone variations for different contexts
+```
+
+### Automated Copy Testing
+
+```
+Every week, I'll share new designs with you. For each design:
+1. Extract all copy
+2. Run it through the content usability checklist
+3. Flag anything scoring below 7/10
+4. Provide specific fixes
+5. Track improvements over time
+```
+
+---
+
+## Combining with Other ChatGPT Features
+
+### Upload Screenshots
+
+You can upload screenshots instead of Figma links:
+
+```
+[Upload screenshot of error state]
+
+Using UX writing best practices, review this error message.
+Rewrite it to be more empathetic and actionable.
+```
+
+### Voice Conversations
+
+Use voice mode to brainstorm UX copy:
+
+```
+Let's brainstorm button labels for a file upload feature.
+I want them to be clear, specific, and under 20 characters.
+```
+
+### Integration with Code
+
+```
+Review this error message in my code:
+
+errorMessage = "Invalid input. Please try again."
+
+Using the UX Writing Skill, rewrite this to be more helpful
+and specific about what went wrong.
+```
+
+---
+
+## Resources
+
+### Official Documentation
+- **OpenAI Codex Skills**: [developers.openai.com/codex/skills](https://developers.openai.com/codex/skills/)
+- **ChatGPT Apps**: [chatgpt.com/apps](https://chatgpt.com/apps)
+- **Figma App in ChatGPT**: [chatgpt.com/apps/figma/connector_68df038e0ba48191908c8434991bbac2](https://chatgpt.com/apps/figma/connector_68df038e0ba48191908c8434991bbac2)
+
+### UX Writing Skill Documentation
+- **Main README**: See the repository README.md for installation and overview
+- **SKILL.md**: Core frameworks and patterns
+- **Reference Materials**:
+  - `references/accessibility-guidelines.md`
+  - `references/voice-chart-template.md`
+  - `references/content-usability-checklist.md`
+  - `references/patterns-detailed.md`
+
+### Community
+- Browse the [OpenAI Developer Forum](https://community.openai.com/) for Codex discussions
+- Learn about [creating custom skills](https://developers.openai.com/codex/skills/create-skill)
+
+---
+
+## Feedback & Contributions
+
+Have ideas for improving this integration? Found effective workflows? We'd love to hear:
+- Real-world examples of UX improvements from Figma reviews
+- Tips for content design teams using ChatGPT + Figma + UX Writing Skill
+- Additional prompts or patterns that work well
+
+Open an issue or submit a pull request to share your insights!
+
+---
+
+**Happy designing and writing!** 🎨✍️


### PR DESCRIPTION
Updated documentation to reflect that the UX Writing Skill now works with both Claude and OpenAI Codex. Key changes:

- Updated README title and introduction to mention Codex support
- Added Codex installation instructions alongside Claude instructions
- Created comprehensive guide for using skill with ChatGPT Figma app
- Added ChatGPT Figma app integration documentation
- Updated Figma integration section to cover both Claude Code and ChatGPT
- Updated "How It Works" to explain Codex invocation methods
- Added Codex resources to Related Work section
- Updated team installation instructions for both platforms

New file:
- docs/codex-figma-integration.md: Complete guide for using the skill with OpenAI Codex and ChatGPT's Figma app, including setup, workflows, and troubleshooting.

This makes the skill accessible to both Claude and Codex users, expanding its reach to the broader AI agent ecosystem.