### PR TITLE
Fix auto-rebuild workflow permissions

### DIFF
--- a/.github/workflows/auto-rebuild-skill.yml
+++ b/.github/workflows/auto-rebuild-skill.yml
@@ -15,6 +15,10 @@ jobs:
   rebuild:
     runs-on: ubuntu-latest
 
+    # Grant write permissions to contents so the workflow can push commits
+    permissions:
+      contents: write
+
     # Skip if commit was made by the bot to prevent infinite loops
     if: "!contains(github.event.head_commit.message, '[auto-rebuild]')"
 


### PR DESCRIPTION
Add 'contents: write' permission to allow github-actions bot to push auto-rebuild commits. This fixes the 403 permission denied error.