### PR TITLE
Update auto-rebuild workflow to create PR instead of direct push

### DIFF
--- a/.github/workflows/auto-rebuild-skill.yml
+++ b/.github/workflows/auto-rebuild-skill.yml
@@ -39,11 +39,22 @@ jobs:
           echo "changed=true" >> $GITHUB_OUTPUT
         fi
 
-    - name: Commit updated ZIP
+    - name: Create Pull Request
       if: steps.check_changes.outputs.changed == 'true'
       run: |
+        BRANCH_NAME="auto-rebuild-$(date +%s)"
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
+        git checkout -b "$BRANCH_NAME"
         git add dist/ux-writing-skill.zip
         git commit -m "Auto-rebuild skill package [auto-rebuild]"
-        git push
+        git push -u origin "$BRANCH_NAME"
+
+        # Create PR using GitHub CLI
+        gh pr create \
+          --title "Auto-rebuild skill package" \
+          --body "Automated rebuild of skill package after changes to skill files." \
+          --base main \
+          --head "$BRANCH_NAME"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changed workflow to respect branch protection rules by:
- Creating a timestamped branch for the rebuild
- Committing the updated ZIP to that branch
- Creating a PR to merge into main

This prevents the 'push declined due to repository rule violations' error when main branch requires changes through pull requests.