### PR TITLE
Add support for UX writing agent skill

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A comprehensive UX Writing Skill for Claude and OpenAI Codex. Write accessible, user-centered interface copy with research-backed best practices.">
+    <meta name="description" content="A comprehensive UX Writing Skill for Claude and Codex. Write accessible, user-centered interface copy with research-backed best practices.">
     <title>UX Writing Skill for Claude & Codex</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -854,7 +854,7 @@
         <section class="hero">
             <div class="container">
                 <h2>Write better<br>interface copy</h2>
-                <p class="subtitle">A comprehensive agent skill for Claude and OpenAI Codex that helps content designers and product teams create accessible, user-centered text following research-backed best practices.</p>
+                <p class="subtitle">A comprehensive agent skill for Claude and Codex that helps content designers and product teams create accessible, user-centered text following research-backed best practices.</p>
                 <div class="cta-buttons">
                     <a href="https://github.com/content-designer/ux-writing-skill/raw/main/dist/ux-writing-skill.zip" class="btn btn-primary">Download skill</a>
                     <a href="https://github.com/content-designer/ux-writing-skill" class="btn btn-secondary">View on GitHub</a>
@@ -961,7 +961,7 @@
         <section class="integrations">
             <div class="container">
                 <h3 class="section-title">Figma integration</h3>
-                <p class="intro">Review and improve UX copy directly from your Figma designs. Works with both Claude Code and ChatGPT. Perfect for content designers and product teams.</p>
+                <p class="intro">Review and improve UX copy directly from your Figma designs. Works with both Claude Code and Codex. Perfect for content designers and product teams.</p>
 
                 <div class="feature-grid" style="margin-bottom: 0;">
                     <div class="integration-card" style="background: rgba(186, 205, 217, 0.08); border: 1px solid var(--border); padding: 48px;">
@@ -972,9 +972,9 @@
                     </div>
 
                     <div class="integration-card" style="background: rgba(186, 205, 217, 0.08); border: 1px solid var(--border); padding: 48px;">
-                        <h4>ChatGPT Figma App</h4>
-                        <p class="help-text" style="margin-top: 0; margin-bottom: 24px;">Connect the Figma app in ChatGPT to review designs and generate new ones with optimized UX copy using this skill.</p>
-                        <p style="color: var(--ink-light); font-size: 15px; line-height: 1.6; margin-bottom: 24px;">ChatGPT → Profile → Apps & connectors → Figma → Connect</p>
+                        <h4>Codex + Figma App</h4>
+                        <p class="help-text" style="margin-top: 0; margin-bottom: 24px;">Connect the Figma app in Codex to review designs and generate new ones with optimized UX copy using this skill.</p>
+                        <p style="color: var(--ink-light); font-size: 15px; line-height: 1.6; margin-bottom: 24px;">Codex → Profile → Apps & connectors → Figma → Connect</p>
                         <p class="guide-link"><a href="https://github.com/content-designer/ux-writing-skill/blob/main/docs/codex-figma-integration.md">Read Codex setup guide →</a></p>
                     </div>
                 </div>


### PR DESCRIPTION
Changed all references to be consistent:
- 'OpenAI Codex' → 'Codex'
- 'ChatGPT' → 'Codex' (in context of the Figma integration)
- 'ChatGPT Figma App' → 'Codex + Figma App'

Now consistently uses 'Claude and Codex' throughout the site.