### PR TITLE
Fix auto-rebuild workflow: add pull-requests permission

### DIFF
--- a/.github/workflows/auto-rebuild-skill.yml
+++ b/.github/workflows/auto-rebuild-skill.yml
@@ -15,9 +15,10 @@ jobs:
   rebuild:
     runs-on: ubuntu-latest
 
-    # Grant write permissions to contents so the workflow can push commits
+    # Grant write permissions to contents and pull-requests
     permissions:
       contents: write
+      pull-requests: write
 
     # Skip if commit was made by the bot to prevent infinite loops
     if: "!contains(github.event.head_commit.message, '[auto-rebuild]')"


### PR DESCRIPTION
The workflow was failing with 'Resource not accessible by integration' when trying to create pull requests. Added pull-requests: write permission to allow the github-actions bot to create PRs via GitHub CLI.