### PR TITLE
Fix Figma integration styling and remove redundant CLI/IDE references

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A comprehensive UX Writing Skill for Claude and Codex CLI/IDE. Write accessible, user-centered interface copy with research-backed best practices.">
+    <meta name="description" content="A comprehensive UX Writing Skill for Claude and Codex. Write accessible, user-centered interface copy with research-backed best practices.">
     <title>UX Writing Skill for Claude & Codex</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -854,7 +854,7 @@
         <section class="hero">
             <div class="container">
                 <h2>Write better<br>interface copy</h2>
-                <p class="subtitle">A comprehensive agent skill for Claude and Codex (CLI/IDE) that helps content designers and product teams create accessible, user-centered text following research-backed best practices.</p>
+                <p class="subtitle">A comprehensive agent skill for Claude and Codex that helps content designers and product teams create accessible, user-centered text following research-backed best practices.</p>
                 <div class="cta-buttons">
                     <a href="https://github.com/content-designer/ux-writing-skill/raw/main/dist/ux-writing-skill.zip" class="btn btn-primary">Download skill</a>
                     <a href="https://github.com/content-designer/ux-writing-skill" class="btn btn-secondary">View on GitHub</a>
@@ -961,7 +961,7 @@
         <section class="integrations">
             <div class="container">
                 <h3 class="section-title">Figma integration</h3>
-                <p class="intro">Review and improve UX copy directly from your Figma designs. Works with both Claude Code and Codex CLI/IDE. Perfect for content designers and product teams.</p>
+                <p class="intro">Review and improve UX copy directly from your Figma designs. Works with both Claude Code and Codex. Perfect for content designers and product teams.</p>
 
                 <div class="feature-grid" style="margin-bottom: 0;">
                     <div class="integration-card" style="background: rgba(186, 205, 217, 0.08); border: 1px solid var(--border); padding: 48px;">
@@ -973,8 +973,8 @@
 
                     <div class="integration-card" style="background: rgba(186, 205, 217, 0.08); border: 1px solid var(--border); padding: 48px;">
                         <h4>Codex + Figma MCP</h4>
-                        <p class="help-text" style="margin-top: 0; margin-bottom: 24px;">Configure Codex to connect with Figma MCP and review designs using Dev Mode links.</p>
-                        <p style="color: var(--ink-light); font-size: 15px; line-height: 1.6; margin-bottom: 24px;"><code style="background: transparent; padding: 0; font-size: 14px;">codex mcp login figma</code></p>
+                        <p class="help-text">Configure Codex to connect with Figma MCP and review designs using Dev Mode links.</p>
+                        <code>codex mcp login figma</code>
                         <p class="guide-link"><a href="https://github.com/content-designer/ux-writing-skill/blob/main/docs/codex-figma-integration.md">Read Codex setup guide →</a></p>
                     </div>
                 </div>
@@ -989,7 +989,7 @@
                     <div class="step">
                         <div class="step-number">Step 1</div>
                         <h4>Download</h4>
-                        <p>Download <strong>ux-writing-skill.zip</strong> — contains the skill file and all supporting documentation for Claude and Codex CLI/IDE.</p>
+                        <p>Download <strong>ux-writing-skill.zip</strong> — contains the skill file and all supporting documentation for Claude and Codex.</p>
                     </div>
 
                     <div class="step">
@@ -1000,8 +1000,8 @@
 
                     <div class="step">
                         <div class="step-number">Step 2 — Codex</div>
-                        <h4>Install in Codex CLI/IDE</h4>
-                        <p>Extract the ZIP and copy to <strong>~/.codex/skills/</strong> (Mac/Linux) or <strong>%USERPROFILE%\.codex\skills\</strong> (Windows), then restart Codex CLI or your IDE.</p>
+                        <h4>Install in Codex</h4>
+                        <p>Extract the ZIP and copy to <strong>~/.codex/skills/</strong> (Mac/Linux) or <strong>%USERPROFILE%\.codex\skills\</strong> (Windows), then restart Codex or your IDE.</p>
                     </div>
 
                     <div class="step">


### PR DESCRIPTION
- Changed Codex code snippet to use same dark code block style as Claude
- Removed '(CLI/IDE)' from all Codex references (redundant since Codex only works there)
- Cleaned up meta description, hero subtitle, and installation steps
- Now both integration cards have consistent styling